### PR TITLE
Add view transitions for team icons on some screens

### DIFF
--- a/src/app/_components/league-table.tsx
+++ b/src/app/_components/league-table.tsx
@@ -33,24 +33,34 @@ export async function LeagueTable() {
           <TableRow>
             <TableHead className="px-1 sm:px-2">Team</TableHead>
 
-            <TableHead className="px-1 text-center sm:px-2">Events</TableHead>
-            <TableHead className="px-1 text-center sm:px-2">Wins</TableHead>
-            <TableHead className="px-1 text-center  sm:px-2">Points</TableHead>
+            <TableHead className="px-1 text-center @2xl/libcard:px-2">
+              Events
+            </TableHead>
+            <TableHead className="px-1 text-center @2xl/libcard:px-2">
+              Wins
+            </TableHead>
+            <TableHead className="px-1 text-center  @2xl/libcard:px-2">
+              Points
+            </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {sortedTeams.map((team) => (
             <TableRow key={team.teamName}>
-              <TableCell className="px-1 font-medium sm:px-2">
-                <TeamDisplay team={team} alwaysDisplayLogo={true} />
+              <TableCell className="px-1 font-medium @2xl/libcard:px-2">
+                <TeamDisplay
+                  team={team}
+                  alwaysDisplayLogo={true}
+                  addTransitionName={true}
+                />
               </TableCell>
-              <TableCell className="px-1 text-center sm:px-2">
+              <TableCell className="px-1 text-center @2xl/libcard:px-2">
                 {team.teamPoints.length}
               </TableCell>
-              <TableCell className="px-1 text-center sm:px-2">
+              <TableCell className="px-1 text-center @2xl/libcard:px-2">
                 {team.teamPoints.filter((res) => res.points === 8).length}
               </TableCell>
-              <TableCell className="px-1 text-center sm:px-2">
+              <TableCell className="px-1 text-center @2xl/libcard:px-2">
                 <Link href={`/teams/${team.linkName}`}>
                   {team.teamPoints.reduce((acc, cur) => acc + cur.points, 0)}
                 </Link>
@@ -58,12 +68,6 @@ export async function LeagueTable() {
             </TableRow>
           ))}
         </TableBody>
-        {/* <TableFooter>
-              <TableRow>
-                <TableCell colSpan={3}>Total</TableCell>
-                <TableCell className="text-right">$2,500.00</TableCell>
-              </TableRow>
-            </TableFooter> */}
       </Table>
     </LibCardNarrow>
   );

--- a/src/app/_components/lib-elements.tsx
+++ b/src/app/_components/lib-elements.tsx
@@ -54,6 +54,7 @@ type TeamDisplayProps = {
   team: { id: string; linkName: string; teamName: string };
   alwaysDisplayLogo?: boolean;
   iconOnlyWhenSmall?: boolean;
+  addTransitionName?: boolean;
 };
 
 type TeamDisplayCollapsibleProps = {
@@ -66,13 +67,14 @@ export function TeamDisplay({
   team,
   alwaysDisplayLogo = false,
   iconOnlyWhenSmall = false,
+  addTransitionName = false,
 }: TeamDisplayProps) {
   if (!team) return null;
   return (
     <Link href={`/teams/${team.linkName}`}>
       <div className="flex items-center justify-start">
         <div
-          className={`${iconOnlyWhenSmall ? "sm:mr-2" : "mr-2"} ${!alwaysDisplayLogo && "hidden"} overflow-hidden rounded-full sm:block`}
+          className={`${iconOnlyWhenSmall ? "sm:mr-2" : "mr-2"} ${!alwaysDisplayLogo && "hidden"} overflow-hidden rounded-full sm:block ${addTransitionName ? team.linkName : ""}`}
         >
           <Image
             src={`/${team.linkName}.png`}

--- a/src/app/entrants/[entrantId]/page.tsx
+++ b/src/app/entrants/[entrantId]/page.tsx
@@ -105,7 +105,9 @@ async function Content({ entrantId }: ContentProps) {
     <LibMain>
       {entrant ? (
         <div className="flex flex-col items-center">
-          <div className="h-[100px] w-[100px] overflow-hidden rounded-full ring-2 ring-[hsl(var(--muted))]">
+          <div
+            className={`h-[100px] w-[100px] overflow-hidden rounded-full ring-2 ring-[hsl(var(--muted))] ${entrant.team.linkName}`}
+          >
             <Link href={`/entrants/${entrant.id}`}>
               {entrant?.user?.avatarUrl ? (
                 <Image
@@ -141,13 +143,15 @@ async function Content({ entrantId }: ContentProps) {
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead className="px-1 sm:px-2">Comp</TableHead>
-                <TableHead className="hidden px-1 sm:table-cell sm:px-2">
+                <TableHead className="px-1 @2xl/libcard:px-2">Comp</TableHead>
+                <TableHead className="hidden px-1 @2xl/libcard:table-cell @2xl/libcard:px-2">
                   Date
                 </TableHead>
-                <TableHead className="px-1 sm:px-2">Results</TableHead>
-                <TableHead className="px-1 sm:px-2">Score</TableHead>
-                <TableHead className="px-1 text-right sm:px-2">
+                <TableHead className="px-1 @2xl/libcard:px-2">
+                  Results
+                </TableHead>
+                <TableHead className="px-1 @2xl/libcard:px-2">Score</TableHead>
+                <TableHead className="px-1 text-right @2xl/libcard:px-2">
                   Winnings
                 </TableHead>
               </TableRow>
@@ -158,9 +162,9 @@ async function Content({ entrantId }: ContentProps) {
                   <Collapsible key={comp.compId} asChild>
                     <Fragment key={comp.compId}>
                       <TableRow key={comp.compId}>
-                        <TableCell className="px-1 sm:px-2">
+                        <TableCell className="px-1 @2xl/libcard:px-2">
                           <Link href={`/events/${comp.comp.shortName}`}>
-                            <span className="mr-1 sm:mr-2">
+                            <span className="mr-1 @2xl/libcard:mr-2">
                               {comp.comp.name}
                             </span>
                             {comp.wildcard ? <Badge>WC</Badge> : null}
@@ -168,7 +172,7 @@ async function Content({ entrantId }: ContentProps) {
                         </TableCell>
                         <CollapsibleTrigger asChild>
                           <TableCell
-                            className={`hidden px-1 sm:table-cell sm:px-2 ${comp.scorecard && "cursor-pointer"}`}
+                            className={`hidden px-1 @2xl/libcard:table-cell @2xl/libcard:px-2 ${comp.scorecard && "cursor-pointer"}`}
                           >
                             {new Date(comp.comp.date).toLocaleDateString(
                               "en-GB",
@@ -182,7 +186,7 @@ async function Content({ entrantId }: ContentProps) {
                         </CollapsibleTrigger>
                         <CollapsibleTrigger asChild>
                           <TableCell
-                            className={`px-1 sm:px-2 ${comp.scorecard && "cursor-pointer"}`}
+                            className={`px-1 @2xl/libcard:px-2 ${comp.scorecard && "cursor-pointer"}`}
                           >
                             {comp.position
                               ? `${comp.position}${ordinal(comp.position)}`
@@ -191,14 +195,14 @@ async function Content({ entrantId }: ContentProps) {
                         </CollapsibleTrigger>
                         <CollapsibleTrigger asChild>
                           <TableCell
-                            className={`px-1 sm:px-2 ${comp.scorecard && "cursor-pointer"}`}
+                            className={`px-1 @2xl/libcard:px-2 ${comp.scorecard && "cursor-pointer"}`}
                           >
                             {comp.position
                               ? `${comp.score ? comp.score : "NR"}${comp.comp.stableford ? !comp.noResult && "pts" : ""}`
                               : ""}
                           </TableCell>
                         </CollapsibleTrigger>
-                        <TableCell className="px-1 text-right sm:px-2">
+                        <TableCell className="px-1 text-right @2xl/libcard:px-2">
                           <LibMoney
                             hideZeros={true}
                             amountInPence={comp.transactions.reduce(

--- a/src/app/teams/[teamName]/page.tsx
+++ b/src/app/teams/[teamName]/page.tsx
@@ -34,7 +34,7 @@ export default async function Team({
   return (
     <LibMain>
       <div className=" flex flex-col items-center">
-        <div className="overflow-hidden rounded-full">
+        <div className={`overflow-hidden rounded-full ${team.linkName}`}>
           <Image
             src={`/${team.linkName}.png`}
             height={100}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -182,7 +182,6 @@
   view-transition-name:title-move
 }
 
-
 .league-table {
   view-transition-name:league-table-move
 }
@@ -191,3 +190,38 @@
   view-transition-name:prizewinners-move
 }
 
+.ballsdeep {
+  view-transition-name:ballsdeep-move
+}
+
+.bigsticks {
+  view-transition-name:bigsticks-move
+}
+
+.bogeyboys {
+  view-transition-name:bogeyboys-move
+}
+
+.eurekas {
+  view-transition-name:eurekas-move
+}
+
+.lostballs {
+  view-transition-name:lostballs-move
+}
+
+.regularflex {
+  view-transition-name:regularflex-move
+}
+
+.shanksandbighook {
+  view-transition-name:shanksandbighook-move
+}
+
+.swingers {
+  view-transition-name:swingers-move
+}
+
+.twoballers {
+  view-transition-name:twoballers-move
+}


### PR DESCRIPTION
Add optional view transition name to the TeamDisplay component to animate the icon. Add usage of this to LeagueTable component, /teams/[teamName] &  /entrants/[entrantId] routes.
Add container queries that had been previously missed.