### PR TITLE
Add view transitions when changing between tabs on the Eclectic table

### DIFF
--- a/src/app/_components/eclectic.tsx
+++ b/src/app/_components/eclectic.tsx
@@ -26,6 +26,7 @@ import {
 import { ScorecardDisplay } from "./scorecard";
 import { Skeleton } from "~/components/ui/skeleton";
 import { type EclecticData } from "../eclectic/page";
+import { flushSync } from "react-dom";
 
 type Hole = {
   holeNo: number;
@@ -339,15 +340,30 @@ export default function Eclectic({ scores }: EclecticProps) {
     });
   });
 
+  const setTab = (tabName: "Gross" | "Net") => {
+    // Fallback for browsers that don't support View Transitions:
+    if (!document.startViewTransition) {
+      setGrossOrNet(tabName);
+      return;
+    }
+
+    // With View Transitions:
+    document.startViewTransition(() =>
+      flushSync(() => {
+        setGrossOrNet(tabName);
+      }),
+    );
+  };
+
   return (
     <LibCardContainer>
       <LibCardNarrow title="Eclectic Leaderboard">
         <Tabs className="" defaultValue={grossOrNet}>
           <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger onClick={() => setGrossOrNet("Gross")} value="Gross">
+            <TabsTrigger onClick={() => setTab("Gross")} value="Gross">
               Gross
             </TabsTrigger>
-            <TabsTrigger onClick={() => setGrossOrNet("Net")} value="Net">
+            <TabsTrigger onClick={() => setTab("Net")} value="Net">
               Net
             </TabsTrigger>
           </TabsList>
@@ -366,7 +382,10 @@ export default function Eclectic({ scores }: EclecticProps) {
             {(grossOrNet === "Gross" ? scratch : net).map((score, index) => (
               <Collapsible key={`${grossOrNet}-${score.entrantId}`} asChild>
                 <Fragment key={score.entrantId}>
-                  <TableRow key={score.entrantId}>
+                  <TableRow
+                    key={score.entrantId}
+                    className={`entrant${score.entrantId}`}
+                  >
                     <TableCell className="px-1 hover:cursor-pointer sm:px-2">
                       <CollapsibleTrigger asChild>
                         <span>{index + 1}</span>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -225,3 +225,126 @@
 .twoballers {
   view-transition-name:twoballers-move
 }
+
+.entrant1 {
+  view-transition-name:entrant1-move
+}
+.entrant2 {
+  view-transition-name:entrant2-move
+}
+.entrant3 {
+  view-transition-name:entrant3-move
+}
+.entrant4 {
+  view-transition-name:entrant4-move
+}
+.entrant5 {
+  view-transition-name:entrant5-move
+}
+.entrant6 {
+  view-transition-name:entrant6-move
+}
+.entrant7 {
+  view-transition-name:entrant7-move
+}
+.entrant8 {
+  view-transition-name:entrant8-move
+}
+.entrant9 {
+  view-transition-name:entrant9-move
+}
+.entrant10 {
+  view-transition-name:entrant10-move
+}
+
+.entrant11 {
+  view-transition-name:entrant11-move
+}
+.entrant12 {
+  view-transition-name:entrant12-move
+}
+.entrant13 {
+  view-transition-name:entrant13-move
+}
+.entrant14 {
+  view-transition-name:entrant14-move
+}
+.entrant15 {
+  view-transition-name:entrant15-move
+}
+.entrant16 {
+  view-transition-name:entrant16-move
+}
+.entrant17 {
+  view-transition-name:entrant17-move
+}
+.entrant18 {
+  view-transition-name:entrant18-move
+}
+.entrant19 {
+  view-transition-name:entrant19-move
+}
+.entrant20 {
+  view-transition-name:entrant20-move
+}
+.entrant21 {
+  view-transition-name:entrant21-move
+}
+.entrant22 {
+  view-transition-name:entrant22-move
+}
+.entrant23 {
+  view-transition-name:entrant23-move
+}
+.entrant24 {
+  view-transition-name:entrant24-move
+}
+.entrant25 {
+  view-transition-name:entrant25-move
+}
+.entrant26 {
+  view-transition-name:entrant26-move
+}
+.entrant27 {
+  view-transition-name:entrant27-move
+}
+.entrant28 {
+  view-transition-name:entrant28-move
+}
+.entrant29 {
+  view-transition-name:entrant29-move
+}
+.entrant30 {
+  view-transition-name:entrant30-move
+}
+.entrant31 {
+  view-transition-name:entrant31-move
+}
+.entrant32 {
+  view-transition-name:entrant32-move
+}
+.entrant33 {
+  view-transition-name:entrant33-move
+}
+.entrant34 {
+  view-transition-name:entrant34-move
+}
+.entrant35 {
+  view-transition-name:entrant35-move
+}
+.entrant36 {
+  view-transition-name:entrant36-move
+}
+.entrant37 {
+  view-transition-name:entrant37-move
+}
+.entrant38 {
+  view-transition-name:entrant38-move
+}
+.entrant39 {
+  view-transition-name:entrant39-move
+}
+.entrant40 {
+  view-transition-name:entrant40-move
+}
+


### PR DESCRIPTION
Add view transition names to the entrant table rows in the eclectic table.
Trigger a view transition when the tab state is changed and view transitions are supported.
Use flushSync to ensure Dom is re-rendered within the view transition.

End result: Entrants rejiggle themselves into place when the tab is changed.