### PR TITLE
Add start view transition to PageHeader logo link to Home

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { Link } from "next-view-transitions";
 // import { MobileNav } from "./MobileNav";
 
 import { UserButton } from "@clerk/nextjs";


### PR DESCRIPTION
Change Link reference in PageHeader.tsx to use the next-view-transitions version. This will trigger view transitions when user clicks the main logo to navigate to the home page