### PR TITLE
Add Changes to support multi-round events

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,6 +96,7 @@ model Comp {
     lib                Boolean             @default(true)
     eclectic           Boolean             @default(true)
     resultsPage        String              @default("")
+    round              String              @default("") @map("round")
     entrants           CompEntrant[]
     teamPoints         TeamPoints[]
     transactions       Transaction[]

--- a/src/app/_components/event-list.tsx
+++ b/src/app/_components/event-list.tsx
@@ -86,6 +86,7 @@ type EventListDisplayProps = {
     lib: boolean;
     eclectic: boolean;
     resultsPage: string;
+    round: string;
   }>;
   title?: string;
   lastHeaderText?: string;
@@ -152,6 +153,7 @@ function EventListDisplay({
                       lib={comp.lib}
                       eclectic={comp.eclectic}
                       resultsPage={comp.resultsPage}
+                      round={comp.round}
                     />
                   )}
                 </TableCell>

--- a/src/app/_components/events.tsx
+++ b/src/app/_components/events.tsx
@@ -32,6 +32,7 @@ type EditEventType = {
   lib: boolean;
   eclectic: boolean;
   resultsPage: string;
+  round: string;
 };
 export function EditEventDialog({
   igCompId,
@@ -42,6 +43,7 @@ export function EditEventDialog({
   lib,
   eclectic,
   resultsPage,
+  round,
 }: EditEventType) {
   const [linkName, setLinkName] = useState<string>(shortName);
   const [fullName, setFullName] = useState<string>(name);
@@ -50,6 +52,7 @@ export function EditEventDialog({
   const [isLib, setIsLib] = useState<boolean>(lib);
   const [isEclectic, setIsEclectic] = useState<boolean>(eclectic);
   const [results, setResults] = useState<string>(resultsPage);
+  const [roundId, setRoundId] = useState<string>(round);
   const router = useRouter();
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -62,6 +65,7 @@ export function EditEventDialog({
     setIsLib(lib);
     setIsEclectic(eclectic);
     setResults(resultsPage);
+    setRoundId(round ?? "");
   };
 
   const event = api.comp.update.useMutation({
@@ -164,13 +168,23 @@ export function EditEventDialog({
             <Label htmlFor="eclectic">Eclectic event?</Label>
           </div>
           <div className="grid gap-2">
-            <Label htmlFor="fullname">GG Results Page</Label>
+            <Label htmlFor="ggResults">GG Results Page</Label>
             <Input
               id="ggResults"
               type="text"
               placeholder="Enter Results Page Number"
               value={results}
               onChange={(evt) => setResults(evt.target.value)}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="ggRound">GG Round Id</Label>
+            <Input
+              id="ggRound"
+              type="text"
+              placeholder="Enter Round Id"
+              value={roundId}
+              onChange={(evt) => setRoundId(evt.target.value)}
             />
           </div>
         </div>
@@ -197,7 +211,8 @@ export function EditEventDialog({
               isStableford === stableford &&
               isLib === lib &&
               isEclectic === eclectic &&
-              resultsPage === results
+              resultsPage === results &&
+              roundId === round
             }
             onClick={() => {
               event.mutate({
@@ -209,6 +224,7 @@ export function EditEventDialog({
                 lib: isLib,
                 eclectic: isEclectic,
                 resultsPage: results,
+                round: roundId,
               });
             }}
           >

--- a/src/app/_components/resultslookup.tsx
+++ b/src/app/_components/resultslookup.tsx
@@ -42,6 +42,7 @@ type ScrapeResultProps = {
   resultsPage: string;
   compFormat: "Medal" | "Stableford";
   compName: string;
+  round: string;
 };
 
 type ResultsObjectType = {
@@ -56,6 +57,7 @@ export function ScrapeResults({
   resultsPage,
   compFormat,
   compName,
+  round,
 }: ScrapeResultProps) {
   const [results, setResults] = useState<ScrapedResultsType | null>(null);
   const [eclectic, setEclectic] = useState<ScrapedEclecticType | null>(null);
@@ -104,6 +106,7 @@ export function ScrapeResults({
         compFormat,
         compName,
         true,
+        round,
       );
       setResults(processedResults.results);
       setMissingEntrants(processedResults.checks.missingEntrants);
@@ -123,6 +126,7 @@ export function ScrapeResults({
         compFormat,
         compName,
         false,
+        round,
       );
       setResults(processedResults.results);
       setMissingEntrants(processedResults.checks.missingEntrants);
@@ -267,6 +271,7 @@ export function ScrapeResults({
         compFormat,
         compName,
         true,
+        round,
       );
       // console.log("========Scraped Scores--------", scrapedEclectic);
       setEclectic(scrapedEclectic);
@@ -280,6 +285,7 @@ export function ScrapeResults({
         compFormat,
         compName,
         false,
+        round,
       );
       // console.log("========Scraped Scores--------", scrapedEclectic);
       setEclectic(scrapedEclectic);

--- a/src/app/events/[eventId]/page.tsx
+++ b/src/app/events/[eventId]/page.tsx
@@ -188,6 +188,7 @@ export default async function Event({
                   resultsPage={comp.resultsPage}
                   compFormat={comp.stableford ? "Stableford" : "Medal"}
                   compName={comp.name}
+                  round={comp.round}
                 />
               </LibCardNarrow>
             </TabsContent>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -46,7 +46,13 @@ export default authMiddleware({
       return NextResponse.next();
     }
     // Admin routes=====================
-    const adminRoutes = ["/users", "/admin/entrants", "/admin/events"];
+    const adminRoutes = [
+      "/users",
+      "/admin/entrants",
+      "/admin/events",
+      "/admin/scorecards",
+      "/admin/scorecards/:path",
+    ];
 
     if (adminRoutes.includes(req.nextUrl.pathname)) {
       if (!auth.sessionClaims?.metadata?.adminPermission) {

--- a/src/server/api/routers/comp.ts
+++ b/src/server/api/routers/comp.ts
@@ -24,6 +24,7 @@ export const compRouter = createTRPCRouter({
         lib: z.boolean(),
         eclectic: z.boolean(),
         resultsPage: z.string(),
+        round: z.string(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -47,6 +48,7 @@ export const compRouter = createTRPCRouter({
             lib: input.lib,
             eclectic: input.eclectic,
             resultsPage: input.resultsPage,
+            round: input.round,
           },
         });
       }


### PR DESCRIPTION
Changes to the result scraping process to support selecting the dropdown to select the correct day ad then to select the right event to expand (although this has been hard-coded for now)